### PR TITLE
Gcp support HostZone

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -166,8 +166,8 @@ HOSTARCH="${HOSTARCH:-amd64}"
 BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${HOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
-# tag as master so that config/package/install.yaml can be used
-PACKAGE_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:master"
+# tag as v0.11.0 so that config/package/install.yaml can be used
+PACKAGE_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:v0.11.0"
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-INTTESTS}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"

--- a/config/package/manifests/resources/cache.gcp.crossplane.io/cloudmemorystoreinstanceclass.resource.yaml
+++ b/config/package/manifests/resources/cache.gcp.crossplane.io/cloudmemorystoreinstanceclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A CloudMemorystoreInstanceClass is a non-portable resource class
 overview: |
  "A CloudMemorystoreInstanceClass is a non-portable resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource."
 readme: |
- Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/cache.gcp.crossplane.io/CloudMemorystoreInstanceClass/v1beta1).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/cache.gcp.crossplane.io/CloudMemorystoreInstanceClass/v1beta1@v0.11.0).

--- a/config/package/manifests/resources/compute.gcp.crossplane.io/gkeclusterclass.resource.yaml
+++ b/config/package/manifests/resources/compute.gcp.crossplane.io/gkeclusterclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A GKEClusterClass is a non-portable resource class. It defines t
 overview: |
  "A GKEClusterClass is a non-portable resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource."
 readme: |
- Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/compute.gcp.crossplane.io/GKEClusterClass/v1alpha3).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/compute.gcp.crossplane.io/GKEClusterClass/v1alpha3@v0.11.0).

--- a/config/package/manifests/resources/container.gcp.crossplane.io/gkeclusterclass.resource.yaml
+++ b/config/package/manifests/resources/container.gcp.crossplane.io/gkeclusterclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A GKEClusterClass is a non-portable resource class. It defines t
 overview: |
  "A GKEClusterClass is a non-portable resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource."
 readme: |
- Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/container.gcp.crossplane.io/GKEClusterClass/v1beta1).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/container.gcp.crossplane.io/GKEClusterClass/v1beta1@v0.11.0).

--- a/config/package/manifests/resources/database.gcp.crossplane.io/cloudsqlinstanceclass.resource.yaml
+++ b/config/package/manifests/resources/database.gcp.crossplane.io/cloudsqlinstanceclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A CloudsqlInstanceClass is a non-portable resource class. It def
 overview: |
  "A CloudsqlInstanceClass is a non-portable resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource."
 readme: |
- Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/database.gcp.crossplane.io/CloudSQLInstanceClass/v1beta1).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/database.gcp.crossplane.io/CloudSQLInstanceClass/v1beta1@v0.11.0).

--- a/config/package/manifests/resources/gcp.crossplane.io/provider.resource.yaml
+++ b/config/package/manifests/resources/gcp.crossplane.io/provider.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A Provider configures a GCP 'provider', i.e. a connection to a p
 overview: |
  "A Provider configures a GCP 'provider', i.e. a connection to a particular GCP project using a particular GCP service account"
 readme: |
- Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/gcp.crossplane.io/Provider/v1alpha3).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/gcp.crossplane.io/Provider/v1alpha3@v0.11.0).

--- a/config/package/manifests/resources/storage.gcp.crossplane.io/bucketclass.resource.yaml
+++ b/config/package/manifests/resources/storage.gcp.crossplane.io/bucketclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A BucketClass is a non-portable resource class. It defines the d
 overview: |
  "A BucketClass is a non-portable resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource."
 readme: |
- Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/storage.gcp.crossplane.io/BucketClass/v1alpha3).
+ Full documentation can be found in the Crossplane [API Reference docs](https://doc.crds.dev/github.com/crossplane/provider-gcp/storage.gcp.crossplane.io/BucketClass/v1alpha3@v0.11.0).

--- a/config/package/samples/install.package.yaml
+++ b/config/package/samples/install.package.yaml
@@ -5,4 +5,4 @@ metadata:
   name: provider-gcp
   namespace: gcp
 spec:
-  package: "crossplane/provider-gcp:master"
+  package: "crossplane/provider-gcp:v0.11.0"

--- a/examples/provider-gcp.yaml
+++ b/examples/provider-gcp.yaml
@@ -5,4 +5,4 @@ metadata:
   name: provider-gcp
   namespace: crossplane-system
 spec:
-  package: "crossplane/provider-gcp:master"
+  package: "crossplane/provider-gcp:v0.11.0"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

Support HostZone for gcp platform
The example is here
```
---
apiVersion: managedzone.gcp.crossplane.io/v1alpha1
kind: ManagedZone
metadata:
  name: my-little-zone
spec:
  forProvider:
    name: test--fang--23645c95
    network: test
    description: fang-test-123
    dnsName: us-west1.dev.gcp.tidbcloud.com.
  reclaimPolicy: Delete
  writeConnectionSecretToRef:
    name: little-managedzone-big-secret
    namespace: crossplane-system
  providerRef:
    name: gcp-provider
```

### Test
Manually Test

- Hostzone is create successful by the crd.
- Hostzone is deleted successfule by the crd.
