### PR TITLE
Update kernel security base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10 as base
+FROM pingcap/alpine-glibc:alpine-3.14.3 as base
 
 # this fils is generate by go build
 COPY crossplane-gcp-provider  /crossplane-gcp-provider


### PR DESCRIPTION
### changes


Replace DBaaS alpine to "pingcap/alpine-glibc:alpine-3.14.3"
this is the kernel security base image 


[pingcap/alpine-glibc:alpine-3.14.3](https://hub.docker.com/layers/pingcap/alpine-glibc/alpine-3.14.3/images/sha256-92e60474d20a52cde74b9a5a538bcbd3c0c477d5f2f9873bf88fea540a779833?context=explore)



